### PR TITLE
Rename Formula to az-kubelogin / M1 support

### DIFF
--- a/Formula/az-kubelogin.rb
+++ b/Formula/az-kubelogin.rb
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+class AzKubelogin < Formula
+  desc "A Kubernetes credential (exec) plugin implementing azure authentication"
+  homepage "https://github.com/Azure/kubelogin"
+  version "0.0.10"
+  license "MIT"
+
+  case
+  when OS.mac? && Hardware::CPU.intel?
+    url "https://github.com/Azure/kubelogin/releases/download/v#{version}/kubelogin-darwin-amd64.zip"
+    sha256 "e4d155139d36fc489d4366ca818c9c400bf35ebe347b0f1d5bb84864b406d420"
+  when OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/Azure/kubelogin/releases/download/v#{version}/kubelogin-darwin-arm64.zip"
+    sha256 "793f72b1d757a1404169680ffc35427c2d62e557a88503dc74f43bb9bfedf2b5"
+  when OS.linux? && Hardware::CPU.intel?
+    url "https://github.com/Azure/kubelogin/releases/download/v#{version}/kubelogin-linux-amd64.zip"
+    sha256 "2098de5b617fcfc1653c435488a2fc4cd32bdd2450fee17cdf5b1b3c08f6889b"
+  else
+    odie "Unexpected platform!"
+  end
+  
+  def install
+    case
+    when OS.mac? && Hardware::CPU.intel?
+      bin.install "darwin_amd64/kubelogin" => "az-kubelogin"
+    when OS.mac? && Hardware::CPU.arm?
+      bin.install "darwin_arm64/kubelogin" => "az-kubelogin"
+    when OS.linux? && Hardware::CPU.intel?
+      bin.install "linux_amd64/kubelogin" => "az-kubelogin"
+    else
+      odie "Unexpected platform!"
+    end
+  end
+
+  test do
+    system "#{bin}/az-kubelogin --version"
+  end
+end

--- a/Formula/kubelogin.rb
+++ b/Formula/kubelogin.rb
@@ -7,21 +7,30 @@ class Kubelogin < Formula
   version "0.0.10"
   license "MIT"
 
-  if OS.mac?
+  case
+  when OS.mac? && Hardware::CPU.intel?
     url "https://github.com/Azure/kubelogin/releases/download/v#{version}/kubelogin-darwin-amd64.zip"
     sha256 "e4d155139d36fc489d4366ca818c9c400bf35ebe347b0f1d5bb84864b406d420"
-  end
-  if OS.linux?
+  when OS.mac? && Hardware::CPU.arm?
+    url "https://github.com/Azure/kubelogin/releases/download/v#{version}/kubelogin-darwin-arm64.zip"
+    sha256 "793f72b1d757a1404169680ffc35427c2d62e557a88503dc74f43bb9bfedf2b5"
+  when OS.linux? && Hardware::CPU.intel?
     url "https://github.com/Azure/kubelogin/releases/download/v#{version}/kubelogin-linux-amd64.zip"
     sha256 "2098de5b617fcfc1653c435488a2fc4cd32bdd2450fee17cdf5b1b3c08f6889b"
+  else
+    odie "Unexpected platform!"
   end
 
   def install
-    if OS.mac?
+    case
+    when OS.mac? && Hardware::CPU.intel?
       bin.install "darwin_amd64/kubelogin"
-    end
-    if OS.linux?
+    when OS.mac? && Hardware::CPU.arm?
+      bin.install "darwin_arm64/kubelogin"
+    when OS.linux? && Hardware::CPU.intel?
       bin.install "linux_amd64/kubelogin"
+    else
+      odie "Unexpected platform!"
     end
   end
 


### PR DESCRIPTION
There are other homebrew formulas out there that use the same name
e.g. https://github.com/int128/kubelogin
So in order to avoid conflicts, rename to something slightly more
specific, `az-kubelogin` seems close enough.

Also support arm64 / m1 macbooks.